### PR TITLE
Add missing methods for Handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.4.0",
     "jest-tobetype": "^1.2.3",
-    "mediasoup-client": "^3.6.5",
+    "mediasoup-client": "<=3.6.52",
     "open-cli": "^6.0.1",
     "tsc-watch": "^4.2.3",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "mediasoup-client": "^3.6.2"
+    "mediasoup-client": "<=3.6.52"
   }
 }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -611,7 +611,6 @@ export class Handler extends HandlerInterface
 			maxRetransmits,
 			label,
 			protocol,
-			priority // eslint-disable-line @typescript-eslint/no-unused-vars
 		}: HandlerSendDataChannelOptions
 	): Promise<HandlerSendDataChannelResult>
 	{

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -885,6 +885,51 @@ export class Handler extends HandlerInterface
 			answer as RTCSessionDescription);
 	}
 
+	async resumeReceiving(localIds: string[]): Promise<void>
+	{
+		this._assertRecvDirection();
+
+		for (const localId of localIds)
+		{
+			logger.debug('pauseReceiving() [localId:%s]', localId);
+
+			const track = this._mapLocalIdTracks.get(localId);
+
+			if (!track)
+				throw new Error('associated track not found');
+
+			const mid = this._mapLocalIdMid.get(localId);
+
+			if (!mid)
+				throw new Error('associated MID not found');
+
+			await this._channel.request('handler.setTrackDirection', this._internal, { localId, direction: 'recvonly'});
+		}
+
+		const offer = await this._channel.request('handler.createOffer', this._internal);
+
+		logger.debug(
+			'resumeReceiving() | calling handler.setRemoteDescription() [offer:%o]',
+			offer);
+
+		await this._channel.request(
+			'handler.setRemoteDescription',
+			this._internal,
+			offer as RTCSessionDescription);
+
+		const answer = await this._channel.request(
+			'handler.createAnswer', this._internal);
+
+		logger.debug(
+			'resumeReceiving() | calling handler.setLocalDescription() [answer:%o]',
+			answer);
+
+		await this._channel.request(
+			'handler.setLocalDescription',
+			this._internal,
+			answer as RTCSessionDescription);
+	}
+
 	async getReceiverStats(localId: string): Promise<FakeRTCStatsReport>
 	{
 		this._assertRecvDirection();

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -423,6 +423,47 @@ export class Handler extends HandlerInterface
 			answer as RTCSessionDescription);
 	}
 
+	async pauseSending(localId: string): Promise<void>
+	{
+		this._assertSendDirection();
+
+		logger.debug('pauseSending() [localId:%s]', localId);
+
+		const track = this._mapLocalIdTracks.get(localId);
+
+		if (!track)
+			throw new Error('associated track not found');
+
+		const mid = this._mapLocalIdMid.get(localId);
+
+		if (!mid)
+			throw new Error('associated MID not found');
+
+		await this._channel.request('handler.setTrackDirection', this._internal, { localId, direction: 'inactive'});
+
+		const offer = await this._channel.request('handler.createOffer', this._internal);
+
+		logger.debug(
+			'pauseSending() | calling handler.setLocalDescription() [offer:%o]',
+			offer);
+
+		await this._channel.request(
+			'handler.setLocalDescription',
+			this._internal,
+			offer as RTCSessionDescription);
+
+		const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+
+		logger.debug(
+			'stopSending() | calling handler.setRemoteDescription() [answer:%o]',
+			answer);
+
+		await this._channel.request(
+			'handler.setRemoteDescription',
+			this._internal,
+			answer as RTCSessionDescription);
+  }
+
 	async replaceTrack(
 		localId: string, track: MediaStreamTrack | null
 	): Promise<void>

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -122,7 +122,7 @@ export class Handler extends HandlerInterface
 			this._channel.notify('handler.close', this._internal);
 
 		// Tell the parent.
-		this.emit('@close');
+	  this.emit('@connectionstatechange', 'closed');
 	}
 
 	async getNativeRtpCapabilities(): Promise<RtpCapabilities>

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -262,7 +262,7 @@ export class Handler extends HandlerInterface
 		}
 
 		const sendingRtpParameters =
-			utils.clone(this._sendingRtpParametersByKind[track.kind]);
+			utils.clone(this._sendingRtpParametersByKind[track.kind], {});
 
 		// This may throw.
 		sendingRtpParameters.codecs =

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -287,7 +287,10 @@ export class Worker extends EnhancedEventEmitter
 				});
 
 			this._handlers.add(handler);
-			handler.on('@close', () => this._handlers.delete(handler));
+		  handler.on('@connectionstatechange', (state) => {
+            if (state === "closed")
+              this._handlers.delete(handler);
+          });
 
 			return handler;
 		};

--- a/src/media.ts
+++ b/src/media.ts
@@ -41,7 +41,7 @@ export async function getUserMedia(
 	constraints: AiortcMediaStreamConstraints = {}
 ): Promise<AiortcMediaStream>
 {
-	constraints = clone(constraints) as AiortcMediaStreamConstraints;
+	constraints = clone(constraints, {}) as AiortcMediaStreamConstraints;
 
 	let { audio, video } = constraints;
 	let audioPlayerInternal: MediaPlayerInternal;

--- a/worker/handler.py
+++ b/worker/handler.py
@@ -244,6 +244,18 @@ class Handler:
 
             transceiver.sender.replaceTrack(track)
 
+        elif request.method == "handler.setTrackDirection":
+            data = request.data
+            localId = data.get("localId")
+            direction = data.get("direction")
+            if localId is None:
+                raise TypeError("missing data.localId")
+            if direction is None:
+                raise TypeError("missing data.direction")
+
+            transceiver = self._sendTransceivers[localId]
+            transceiver.direction = direction
+
         elif request.method == "handler.getTransportStats":
             result = {}
             stats = await self._pc.getStats()


### PR DESCRIPTION
Refs: https://github.com/versatica/mediasoup-client-aiortc/issues/16

Before I change `safeEmitAsPromise` method, I added missing methods for the handler in mediasoup-client 3.6.52.  These methods are required to pass compile.

- Add `pauseSending`
- Add `resumeSending`
- Add `pauseReceiving`
- Add `resumeReceiving`
- Fix `receive`