### PR TITLE
Fix message event in FakeRTCDataChannel

### DIFF
--- a/lib/FakeRTCDataChannel.js
+++ b/lib/FakeRTCDataChannel.js
@@ -166,7 +166,7 @@ class FakeRTCDataChannel extends event_target_shim_1.EventTarget {
                 case 'message':
                     {
                         // @ts-ignore
-                        this.dispatchEvent(new event_target_shim_1.Event('message', { data }));
+                        this.dispatchEvent(new MessageEvent('message', { data }));
                         break;
                     }
                 case 'binary':
@@ -178,7 +178,7 @@ class FakeRTCDataChannel extends event_target_shim_1.EventTarget {
                             view[i] = buffer[i];
                         }
                         // @ts-ignore
-                        this.dispatchEvent(new event_target_shim_1.Event('message', { data: arrayBuffer }));
+                        this.dispatchEvent(new MessageEvent('message', { data: arrayBuffer }));
                         break;
                     }
                 case 'bufferedamountlow':

--- a/src/FakeRTCDataChannel.ts
+++ b/src/FakeRTCDataChannel.ts
@@ -298,7 +298,7 @@ export class FakeRTCDataChannel extends EventTarget implements RTCDataChannel
 				case 'message':
 				{
 					// @ts-ignore
-					this.dispatchEvent(new Event('message', { data }));
+					this.dispatchEvent(new MessageEvent('message', { data }));
 
 					break;
 				}
@@ -315,7 +315,7 @@ export class FakeRTCDataChannel extends EventTarget implements RTCDataChannel
 					}
 
 					// @ts-ignore
-					this.dispatchEvent(new Event('message', { data: arrayBuffer }));
+					this.dispatchEvent(new MessageEvent('message', { data: arrayBuffer }));
 
 					break;
 				}


### PR DESCRIPTION
Refs #20 

I found the cause.

Event of `event-target-shim` does not have `data` attribute.
https://github.com/mysticatea/event-target-shim/blob/a37993c95ed9cc1d7cb89358ea126ed4f95372e8/src/lib/event.ts#L54

In the previous code, we didn't use the Event class: https://github.com/versatica/mediasoup-client-aiortc/blob/6a1e648f1fe8fbd2a29019af66c90a79bc043da5/src/FakeRTCDataChannel.ts#L244

So, to fix it, we need to use the previous method or another Event class with a `data` attribute. In this PR, I use MessageEvent class.