### PR TITLE
Use a single and bidirectional socket to communicate with the worker (fix Python3 <= 3.10 requirement)

### DIFF
--- a/.github/workflows/mediasoup-client-aiortc.yaml
+++ b/.github/workflows/mediasoup-client-aiortc.yaml
@@ -42,4 +42,4 @@ jobs:
       # NOTE: Avoid lint:python due to
       # https://github.com/versatica/mediasoup-client-aiortc/issues/25
       - run: npm run lint:node
-      - run: npm run test
+      - run: PYTHON_LOG_TO_STDOUT=true npm run test

--- a/README.md
+++ b/README.md
@@ -256,13 +256,18 @@ When sending, `dataChannel.send()` (and hence `dataProducer.send()`) allows pass
 
 ## Development
 
-In order to run `npm run lint` task, the following Python dependencies are required:
+### Lint task
 
-- `flake8` >= 5.0.4
-- `mypy` >= 0.982
+In order to run `npm run lint` task, install Python dev dependencies:
 
 ```bash
 $ npm run install-python-dev-deps
+```
+
+### Make Python log to stdout/stderr while running tests
+
+```bash
+PYTHON_LOG_TO_STDOUT=true npm run test
 ```
 
 ### Issue with Python >= 3.11

--- a/README.md
+++ b/README.md
@@ -270,30 +270,6 @@ $ npm run install-python-dev-deps
 PYTHON_LOG_TO_STDOUT=true npm run test
 ```
 
-### Issue with Python >= 3.11
-
-See https://github.com/versatica/mediasoup-client-aiortc/issues/22.
-
-As a workaround:
-
-1. Install `python@3.10`.
-2. Make `PYTHON` environment variable point to it:
-  ```bash
-  export PYTHON=python3.10
-  ```
-3. Make `PIP` environment variable point to `pip@3.10`:
-  ```bash
-  export PIP=pip3.10
-  ```
-4. Install deps:
-  ```bash
-  npm ci
-  ```
-5. Run tests:
-  ```bash
-  npm test
-  ```
-
 
 ## Caveats
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
         }
       ]
     },
+    "coveragePathIgnorePatterns": [
+      "src/tests"
+    ],
     "cacheDirectory": ".cache/jest"
   },
   "dependencies": {

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -75,14 +75,12 @@ export class Worker extends EnhancedEventEmitter
 				// fd 0 (stdin)   : Just ignore it.
 				// fd 1 (stdout)  : Pipe it for 3rd libraries that log their own stuff.
 				// fd 2 (stderr)  : Same as stdout.
-				// fd 3 (channel) : Producer Channel fd.
-				// fd 4 (channel) : Consumer Channel fd.
+				// fd 3 (channel) : Channel fd.
 				stdio :
 				[
 					'ignore',
 					PYTHON_LOG_VIA_PIPE ? 'pipe' : 'inherit',
 					PYTHON_LOG_VIA_PIPE ? 'pipe' : 'inherit',
-					'pipe',
 					'pipe'
 				]
 			});
@@ -91,9 +89,8 @@ export class Worker extends EnhancedEventEmitter
 
 		this.#channel = new Channel(
 			{
-				sendSocket : this.#child.stdio[3],
-				recvSocket : this.#child.stdio[4],
-				pid        : this.#pid
+				socket : this.#child.stdio[3],
+				pid    : this.#pid
 			});
 
 		let spawnDone = false;

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -110,7 +110,7 @@ test('worker.getUserMedia() succeeds', async () =>
 				players  : [],
 				handlers : []
 			});
-}, 5000);
+}, 15000);
 
 test('create a Device with worker.createHandlerFactory() as argument succeeds', () =>
 {
@@ -418,7 +418,7 @@ test('transport.produce() succeeds', async () =>
 
 	sendTransport.removeAllListeners('connect');
 	sendTransport.removeAllListeners('produce');
-}, 5000);
+}, 15000);
 
 test('transport.consume() succeeds', async () =>
 {
@@ -761,7 +761,7 @@ test('producer.replaceTrack() succeeds', async () =>
 				trackId : secondAudioProducer.track!.id
 			}
 		});
-}, 5000);
+}, 15000);
 
 test('producer.getStats() succeeds', async () =>
 {

--- a/worker/channel.py
+++ b/worker/channel.py
@@ -34,9 +34,8 @@ Channel class
 
 
 class Channel:
-    def __init__(self, readfd, writefd) -> None:
-        self._readfd = readfd
-        self._writefd = writefd
+    def __init__(self, fd) -> None:
+        self._fd = fd
         self._reader = Optional[StreamReader]
         self._writer = Optional[StreamWriter]
         self._nsDecoder = pynetstring.Decoder()
@@ -49,16 +48,9 @@ class Channel:
         """
         Create the sender and receivers
         """
-        rsock = socket.socket(
-            socket.AF_UNIX, socket.SOCK_STREAM, 0, self._readfd)
-        self._reader, writer = await asyncio.open_connection(
-            sock=rsock)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0, self._fd)
 
-        wsock = socket.socket(
-            socket.AF_UNIX, socket.SOCK_STREAM, 0, self._writefd)
-        reader, self._writer = await asyncio.open_connection(
-            sock=wsock)
-
+        self._reader, self._writer = await asyncio.open_connection(sock=sock)
         self._connected = True
 
     async def close(self) -> None:

--- a/worker/channel.py
+++ b/worker/channel.py
@@ -57,8 +57,7 @@ class Channel:
         if self._writer is not None:
             self._writer.close()
 
-        if self._reader is not None:
-            self._reader.close()
+        # NOTE: For whatever reason I don't remember, we must not close self._reader.
 
     async def receive(self) -> Optional[Dict[str, Any]]:
         await self._connect()

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -9,9 +9,8 @@ from channel import Request, Notification, Channel
 from handler import Handler
 from logger import Logger
 
-# File descriptors to communicate with the Node.js process
-READ_FD = 3
-WRITE_FD = 4
+# File descriptor to communicate with the Node.js process
+CHANNEL_FD = 3
 
 
 if __name__ == "__main__":
@@ -43,7 +42,7 @@ if __name__ == "__main__":
     loop = asyncio.get_event_loop()
 
     # create channel
-    channel = Channel(READ_FD, WRITE_FD)
+    channel = Channel(CHANNEL_FD)
 
     def getTrack(playerId: str, kind: str) -> MediaStreamTrack:
         player = players[playerId]


### PR DESCRIPTION
### Rationale

- In mediasoup server we used to use also a single bidirectional socket at the beginning, but there was a bug in Node for Windows so we ended spliting it into two (one for sending and one for receiving).
- Anyway, **mediasoup-client-aiortc** doesn't support Windows.
- And probably, such a bug in Node for Windows is already fixed (I don't care).

### Awesome side effect

- This fixes #22 so we can use Python >= 3.11 in our macs :)
- Ok, tests do never complete in CI macOS machines, but anyway.
