### PR TITLE
Make it compatible with typescript 4.x projects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,16 +28,10 @@ export async function createWorker({
  * Expose Worker class and related types.
  */
 export { Worker };
-export type {
-	WorkerSettings,
-	WorkerLogLevel,
-};
+export type { WorkerSettings, WorkerLogLevel };
 
 /**
  * Expose AiortcMediaStream class and related types.
  */
 export { AiortcMediaStream };
-export type {
-	AiortcMediaStreamConstraints,
-	AiortcMediaTrackConstraints,
-};
+export type { AiortcMediaStreamConstraints, AiortcMediaTrackConstraints };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,17 @@ export async function createWorker({
 /**
  * Expose Worker class and related types.
  */
-export { Worker, type WorkerSettings, type WorkerLogLevel };
+export { Worker };
+export type {
+	WorkerSettings,
+	WorkerLogLevel,
+};
 
 /**
  * Expose AiortcMediaStream class and related types.
  */
-export {
-	AiortcMediaStream,
-	type AiortcMediaStreamConstraints,
-	type AiortcMediaTrackConstraints,
+export { AiortcMediaStream };
+export type {
+	AiortcMediaStreamConstraints,
+	AiortcMediaTrackConstraints,
 };

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -120,8 +120,8 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(
-			resolve => ctx.worker?.on('subprocessclose', resolve),
+		await new Promise<void>(resolve =>
+			ctx.worker?.on('subprocessclose', resolve),
 		);
 	}
 }, TEST_TIMEOUT);

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -120,8 +120,8 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve),
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
 		);
 	}
 }, TEST_TIMEOUT);


### PR DESCRIPTION
Projects using a super old typescript 4.x are failing in ts build because of the types importation inside the import...

This PR just make it compatible with old typescript version